### PR TITLE
Add treefmt to format files with `nix fmt`

### DIFF
--- a/docs/_templates/search-field.html
+++ b/docs/_templates/search-field.html
@@ -1,16 +1,21 @@
-{# A bootstrap-styled field that will direct to the `search.html` page when submitted #}
-<form class="bd-search d-flex align-items-center"
-      action="{{ pathto('search') }}"
-      method="get">
+{# A bootstrap-styled field that will direct to the `search.html` page when
+submitted #}
+<form
+  class="bd-search d-flex align-items-center"
+  action="{{ pathto('search') }}"
+  method="get"
+>
   <i class="fa-solid fa-magnifying-glass"></i>
-  <input type="search"
-         class="form-control"
-         name="q"
-         id="search-input"
-         placeholder="{{ theme_search_bar_text }}"
-         aria-label="{{ theme_search_bar_text }}"
-         autocomplete="off"
-         autocorrect="off"
-         autocapitalize="off"
-         spellcheck="false"/>
+  <input
+    type="search"
+    class="form-control"
+    name="q"
+    id="search-input"
+    placeholder="{{ theme_search_bar_text }}"
+    aria-label="{{ theme_search_bar_text }}"
+    autocomplete="off"
+    autocorrect="off"
+    autocapitalize="off"
+    spellcheck="false"
+  />
 </form>

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -67,7 +83,26 @@
         "nixpkgs": "nixpkgs",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
+        "treefmt-nix": "treefmt-nix",
         "uv2nix": "uv2nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     },
     "uv2nix": {

--- a/justfile
+++ b/justfile
@@ -8,9 +8,14 @@ check:
     uv run basedpyright --level error
     uv run ruff check
 
-fmt:
+fmt: fmt-md fmt-py
+
+fmt-md:
+    prettier --write *.md
+
+fmt-py:
     uv run ruff format
-    
+   
 sync:
     uv sync --group dev --group docs
     

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,13 @@
+{
+  projectRootFile = "flake.nix";
+  programs = {
+    alejandra.enable = true;
+    prettier.enable = true;
+    ruff-format.enable = true;
+  };
+  settings.global.excludes = [
+    ".cache/**"
+    ".direnv/**"
+    ".jj/**"
+  ];
+}


### PR DESCRIPTION
Additionally, a justfile target was added to format markdown files with prettier. Thus, running `just fmt` yields the same results as running `nix fmt`.